### PR TITLE
ensure Clipper can access docker.sock regardless of mount

### DIFF
--- a/risecamp_start.sh
+++ b/risecamp_start.sh
@@ -4,6 +4,23 @@
 /opt/pywren/pywren_start.sh
 ./wave/wave_start.sh
 
+# an enchaned kludge to ensure clipper successfully call docker.sock
+# https://stackoverflow.com/questions/23544282/what-is-the-best-way-to-manage-permissions-for-docker-shared-volumes/28596874#28596874
+TARGET_GID=$(stat -c "%g" /var/run/docker.sock)
+
+EXISTS=$(cat /etc/group | grep $TARGET_GID | wc -l)
+
+# Create new group using target GID and add user
+if [ $EXISTS == "0" ]; then
+  groupadd -g $TARGET_GID risecampdocker
+  gpasswd -a $NB_USER risecampdocker
+else
+  # GID exists, find group name and add
+  GROUP=$(getent group $TARGET_GID | cut -d: -f1)
+  gpasswd -a $NB_USER $GROUP
+fi
+
+
 export BW2_DEFAULT_BANKROLL="/home/$NB_USER/wave/ns.ent"
 export BW2_DEFAULT_ENTITY="/home/$NB_USER/wave/ns.ent"
 export NAMESPACE=$(bw2 i /home/$NB_USER/wave/ns.ent | awk '{if($2~"Alias") print $3}')


### PR DESCRIPTION
`mount` copies the GID of `/var/run/docker.sock` from the host to the filesystem inside the docker. This is used by Clipper to create dockers.

if GID of `docker.sock` maps to a non-docker group in the docker, then `$NB_USER` cannot access `docker.sock`, and Clipper fails.

If GID of docker maps to no group in the docker, it is also an issue.

@jey has made a temporary fix for docker for mac to grant the `staff` group to `$NB_USER`. He also mentions that `chgrp` or `chmod` influences the privilleges beyond the docker, which is not a good practice.

This PR finalizes the issue by forcing to add the `$NB_USER` to the GID of `docker.sock`. If such a group does not exist, then a group called `risecampdocker` is added.

@dcrankshaw might be interested in this PR. 

take-home dry run: success for ubuntu 17.04 and mac.