### PR TITLE
[NOT URGENT] Don't hardcode num features in pong model container

### DIFF
--- a/rl_and_pong/pong_model_container.py
+++ b/rl_and_pong/pong_model_container.py
@@ -29,8 +29,8 @@ class PongPolicyContainer(rpc.ModelContainerBase):
         self.agent = PPOAgent('PongJS-v0', config)
         self.agent.restore(path)
         # Run test prediction to load the model
-        print("Predicted {} in constructor".format(
-            self.agent.compute_action(np.random.random(8))))
+        # print("Predicted {} in constructor".format(
+        #     self.agent.compute_action(np.random.random(8))))
 
     def predict_doubles(self, states):
         start = datetime.now()


### PR DESCRIPTION
This makes a change to the model container hosting the pong model. But the image is already pushed to DockerHub, so this can be merged at any time. Even after the RISE camp.