### PR TITLE
Allow projects to add a script to startup

### DIFF
--- a/base/risecamp_start.sh
+++ b/base/risecamp_start.sh
@@ -12,6 +12,12 @@ if [ "${NOTEBOOK_BASE_URL}" != "" ]; then
   NOTEBOOK_FLAGS="${NOTEBOOK_FLAGS} --NotebookApp.base_url=\"${NOTEBOOK_BASE_URL}\""
 fi
 
+# If individual projects need a script to run on startup they can
+# add an ENV to the dockerfile
+if [ "${PRE_START_SCRIPT}" != "" ]; then
+  source ${PRE_START_SCRIPT}
+fi
+
 cd "/home/$NB_USER"
 chown -R "$NB_USER:users" .
 start-notebook.sh ${NOTEBOOK_FLAGS}


### PR DESCRIPTION
Some projects might need to launch background processes before the notebook server starts. This makes it easier to do without specifying a new entrypoint.

E.g wave will use `daemon` to launch `waved`